### PR TITLE
i9300: add zram configuration file

### DIFF
--- a/configs/configure_zram
+++ b/configs/configure_zram
@@ -1,0 +1,27 @@
+#!/sbin/busybox sh
+
+ZRAM_DEVICES="zram0 zram1 zram2 zram3"
+ZRAM_SIZE="629145600"
+NUM_DEVICES="4"
+
+# reset (no need to loop)
+swapoff /dev/block/zram0 > /dev/null 2>&1 &
+swapoff /dev/block/zram1 > /dev/null 2>&1 &
+swapoff /dev/block/zram2 > /dev/null 2>&1 &
+swapoff /dev/block/zram3 > /dev/null 2>&1
+echo 1 > /sys/block/zram0/reset &
+echo 1 > /sys/block/zram1/reset &
+echo 1 > /sys/block/zram2/reset &
+echo 1 > /sys/block/zram3/reset
+
+for ZRAM_DEVICE in $ZRAM_DEVICES; do
+	if [[ -e "/sys/block/$ZRAM_DEVICE/disksize" && -e "/dev/block/$ZRAM_DEVICE" ]]; then
+		echo `expr $ZRAM_SIZE \/ $NUM_DEVICES` > "/sys/block/$ZRAM_DEVICE/disksize"
+		mkswap "/dev/block/$ZRAM_DEVICE"
+		swapon "/dev/block/$ZRAM_DEVICE"
+	fi
+done
+
+echo 80 > /proc/sys/vm/swappiness
+
+exit 0

--- a/i9300.mk
+++ b/i9300.mk
@@ -97,9 +97,12 @@ PRODUCT_COPY_FILES += \
 	frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml \
     frameworks/native/data/etc/android.hardware.telephony.gsm.xml:system/etc/permissions/android.hardware.telephony.gsm.xml
 
-$(call inherit-product-if-exists, vendor/samsung/i9300/i9300-vendor.mk)
-
+# ZRAM
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/configs/configure_zram:system/bin/configure_zram
 
 # Allow tethering without provisioning app
 PRODUCT_PROPERTY_OVERRIDES += \
     net.tethering.noprovisioning=true
+
+$(call inherit-product-if-exists, vendor/samsung/i9300/i9300-vendor.mk)

--- a/rootdir/init.target.rc
+++ b/rootdir/init.target.rc
@@ -52,6 +52,12 @@ service gpsd /system/bin/gpsd -c /system/etc/gps.xml
 on property:init.svc.bootanim=stopped
     write /sys/module/lowmemorykiller/parameters/minfree 12288,15360,18432,21504,24576,30720
 
+# ZRAM configuration file
+service configure_zram /system/bin/configure_zram
+    class late_start
+    user root
+    oneshot
+
 # CyanogenMod Performance Profiles
 
 # Powersave


### PR DESCRIPTION
handling more than 1 zram device does not seem to be possible via fstab
so this is needed