### PR TITLE
i9300: add zram configuration file

### DIFF
--- a/configs/configure_zram
+++ b/configs/configure_zram
@@ -1,0 +1,18 @@
+#!/system/bin/sh
+set -e
+
+ZRAM_DEVICES="zram0 zram1 zram2 zram3"
+ZRAM_SIZE="629145600"
+NUM_DEVICES="4"
+
+for ZRAM_DEVICE in $ZRAM_DEVICES; do
+	if [[ -e "/sys/block/$ZRAM_DEVICE/disksize" && -e "/dev/block/$ZRAM_DEVICE" ]]; then
+		echo `expr $ZRAM_SIZE \/ $NUM_DEVICES` > "/sys/block/$ZRAM_DEVICE/disksize"
+		mkswap "/dev/block/$ZRAM_DEVICE"
+		swapon "/dev/block/$ZRAM_DEVICE"
+	fi
+done
+
+echo 80 > /proc/sys/vm/swappiness
+
+exit 0

--- a/i9300.mk
+++ b/i9300.mk
@@ -97,9 +97,12 @@ PRODUCT_COPY_FILES += \
 	frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml \
     frameworks/native/data/etc/android.hardware.telephony.gsm.xml:system/etc/permissions/android.hardware.telephony.gsm.xml
 
-$(call inherit-product-if-exists, vendor/samsung/i9300/i9300-vendor.mk)
-
+# ZRAM
+PRODUCT_COPY_FILES += \
+    $(LOCAL_PATH)/configs/configure_zram:system/bin/configure_zram
 
 # Allow tethering without provisioning app
 PRODUCT_PROPERTY_OVERRIDES += \
     net.tethering.noprovisioning=true
+
+$(call inherit-product-if-exists, vendor/samsung/i9300/i9300-vendor.mk)

--- a/rootdir/init.target.rc
+++ b/rootdir/init.target.rc
@@ -48,6 +48,12 @@ service gpsd /system/bin/gpsd -c /system/etc/gps.xml
     user gps
     group system inet sdcard_rw
 
+# ZRAM configuration file
+service configure_zram /system/bin/configure_zram
+    class late_start
+    user root
+    oneshot
+
 # LMK
 on property:init.svc.bootanim=stopped
     write /sys/module/lowmemorykiller/parameters/minfree 12288,15360,18432,21504,24576,30720


### PR DESCRIPTION
handling more than 1 zram device does not seem to be possible via fstab
so this is needed